### PR TITLE
Vosk OnPartial returning Null

### DIFF
--- a/ios/Vosk.swift
+++ b/ios/Vosk.swift
@@ -147,7 +147,7 @@ class Vosk: RCTEventEmitter {
                         } else if (!res.completed && self.hasListener && res.result != nil) {
                             // check if partial result is different from last one
                             if (self.lastRecognizedResult == nil || self.lastRecognizedResult!.partial != parsedResult.partial && !parsedResult.partial!.isEmpty) {
-                                self.sendEvent(withName: "onPartialResult", body: parsedResult.partial!.data)
+                                self.sendEvent(withName: "onPartialResult", body: parsedResult.partial)
                             }
                         }
                         self.lastRecognizedResult = parsedResult


### PR DESCRIPTION
Issue: https://github.com/riderodd/react-native-vosk/issues/47

## Problem Summary

iOS `OnPartial` returns a null string to the handler. On investigation, there is a bug with how the `parsedResult.partial`, which is an Optional String, is handled. The React Native Vosk Swift library sends, `parsedResult.partial!.data` instead of `parsedResult.partial` as the value for the callback event. `data` does not exist in the partial text, and a check for the partial string being non-null and different from the last partial string is made before, guaranteeing the partial variable to have a non-null value.