### PR TITLE
Bugfix/#67: App crash on `file://` prefix in dynamic loading

### DIFF
--- a/ios/VoskModel.swift
+++ b/ios/VoskModel.swift
@@ -20,11 +20,12 @@ public final class VoskModel {
 
         let appBundle = Bundle(for: Self.self)
 
+        let name = name.replacingOccurrences(of: "file://", with: "")
         if let loadedModel = vosk_model_new(name) {
             print("Model successfully loaded from path.")
             model = loadedModel
         } else {
-            print("Model directory does not exist at path: \(name)")
+            print("Model directory does not exist at path: \(name). Attempt to load model from main app bundle.")
             // Load model from main app bundle
             if let resourcePath = Bundle.main.resourcePath {
                 let modelPath = resourcePath + "/" + name


### PR DESCRIPTION
# Problem Summary

Issue: #67 
If a path passed in has `file://`, the app crashes in iOS. Alphacephai vosk returns an error that path found is not correct. When a model is not successfully loaded, there is not enough logging to let a user know that a fallback bundle path will be used.

# Summary of Changes
1. Replace `file://` in incoming path with `''` . A user should be able to pass in a path without doing any pre-processing
2. Add more logging for when dynamic load fails and the main bundle path is used. For users who are only doing static loading - something like this is expected. The error is thrown by the original vosk implementation rather than this npm package. Expect to see the second log to start debugging at the main bundle path.

```LOG
ERROR (VoskAPI:Model():model.cc:122) Folder <name> does not contain model files...
Model directory does not exist at path <name>. Attempt to load model from main app bundle.
```
