### PR TITLE
feat(vosk): add transcribeFile API for on-device WAV transcription

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -16,6 +16,8 @@ interface VoskInterface extends TurboModule {
   loadModel: (path: string) => Promise<void>;
   unload: () => void;
 
+  transcribeFile(wavPath: string): Promise<string>;
+
   start: (options?: VoskOptions) => Promise<void>;
   stop: () => void;
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -42,6 +42,14 @@ export default class Vosk {
   loadModel = (path: string) => VoskModule.loadModel(path);
 
   /**
+   * Transcribe a 16 kHz mono WAV file you’ve already extracted.
+   * @param wavPath absolute filesystem path to your .wav
+   * @returns Promise<string>  the Vosk JSON result
+   */
+  transcribeFile = (wavPath: string): Promise<string> =>
+    VoskModule.transcribeFile(wavPath);
+
+  /**
    * Asks for recording permissions then starts the recognizer.
    *
    * @param options - Optional settings for the recognizer.


### PR DESCRIPTION
Add a new `transcribeFile(wavPath: string): Promise<string>` method to the Vosk module.

- Android: implement `@ReactMethod transcribeFile(...)` that streams a 16 kHz mono WAV into a new `Recognizer` and returns its final JSON result.
- JS wrapper: expose `Vosk.transcribeFile = (wavPath) => VoskModule.transcribeFile(wavPath)` and update `VoskInterface` to include the new method.