### PR TITLE
Fix yarn lockfile dependencies

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8424,7 +8424,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-jest@npm:latest":
+"eslint-plugin-jest@npm:^29.0.1":
   version: 29.0.1
   resolution: "eslint-plugin-jest@npm:29.0.1"
   dependencies:
@@ -13691,7 +13691,7 @@ __metadata:
     del-cli: ^6.0.0
     eslint: ^9.35.0
     eslint-config-prettier: ^10.1.8
-    eslint-plugin-jest: latest
+    eslint-plugin-jest: ^29.0.1
     eslint-plugin-prettier: ^5.5.4
     expo-module-scripts: ^5.0.7
     jest: ^29.7.0


### PR DESCRIPTION
Update the `eslint-plugin-jest` dependency version in the yarn lockfile to ensure compatibility and stability.