### PR TITLE
Fix audio permission handling on iOS startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## <small>2.1.7 (2025-11-17)</small>
+
+* fix: Fix format rate error on iOS (#104) ([d8fe8b0](https://github.com/riderodd/react-native-vosk/commit/d8fe8b0)), closes [#104](https://github.com/riderodd/react-native-vosk/issues/104)
+* fix: ios does not asks for audio permission on startup, and model is unloaded properly ([dfa6911](https://github.com/riderodd/react-native-vosk/commit/dfa6911))
+* fix: ios record on simulator (#158) ([f2b1496](https://github.com/riderodd/react-native-vosk/commit/f2b1496)), closes [#158](https://github.com/riderodd/react-native-vosk/issues/158)
+* fix: yarn lockfile (#155) ([507e67d](https://github.com/riderodd/react-native-vosk/commit/507e67d)), closes [#155](https://github.com/riderodd/react-native-vosk/issues/155)
+* #67: replace file:// in name path, have a more descriptive log (#79) ([4e756da](https://github.com/riderodd/react-native-vosk/commit/4e756da)), closes [#67](https://github.com/riderodd/react-native-vosk/issues/67) [#79](https://github.com/riderodd/react-native-vosk/issues/79)
+* Add Expo support for react-native-vosk (#151) ([fec6fb9](https://github.com/riderodd/react-native-vosk/commit/fec6fb9)), closes [#151](https://github.com/riderodd/react-native-vosk/issues/151)
+* Create dependabot.yml (#71) ([8634eba](https://github.com/riderodd/react-native-vosk/commit/8634eba)), closes [#71](https://github.com/riderodd/react-native-vosk/issues/71)
+* fix crashes (#143) ([cc9ea78](https://github.com/riderodd/react-native-vosk/commit/cc9ea78)), closes [#143](https://github.com/riderodd/react-native-vosk/issues/143)
+* Fix expo ios model path (#156) ([e2877d9](https://github.com/riderodd/react-native-vosk/commit/e2877d9)), closes [#156](https://github.com/riderodd/react-native-vosk/issues/156)
+* Fix Expo plugin configuration and dependencies (#152) ([3fa62f7](https://github.com/riderodd/react-native-vosk/commit/3fa62f7)), closes [#152](https://github.com/riderodd/react-native-vosk/issues/152)
+* Fix ios pcm bitrate (#157) ([948534e](https://github.com/riderodd/react-native-vosk/commit/948534e)), closes [#157](https://github.com/riderodd/react-native-vosk/issues/157)
+* Fix/expo ios (#154) ([cbdf9eb](https://github.com/riderodd/react-native-vosk/commit/cbdf9eb)), closes [#154](https://github.com/riderodd/react-native-vosk/issues/154)
+* Fix/update version (#106) ([eeebd52](https://github.com/riderodd/react-native-vosk/commit/eeebd52)), closes [#106](https://github.com/riderodd/react-native-vosk/issues/106)
+* Try to make expo plugin works (#153) ([b54f844](https://github.com/riderodd/react-native-vosk/commit/b54f844)), closes [#153](https://github.com/riderodd/react-native-vosk/issues/153)
+* Update dependabot.yml (#72) ([4013cf3](https://github.com/riderodd/react-native-vosk/commit/4013cf3)), closes [#72](https://github.com/riderodd/react-native-vosk/issues/72)
+* Update issue templates (#76) ([9e4ac88](https://github.com/riderodd/react-native-vosk/commit/9e4ac88)), closes [#76](https://github.com/riderodd/react-native-vosk/issues/76)
+* Update to TurboModules with breaking changes (#150) ([4869ff0](https://github.com/riderodd/react-native-vosk/commit/4869ff0)), closes [#150](https://github.com/riderodd/react-native-vosk/issues/150)
+* Update Vosk Android library and model loading method (#149) ([3248919](https://github.com/riderodd/react-native-vosk/commit/3248919)), closes [#149](https://github.com/riderodd/react-native-vosk/issues/149)
+* docs: add Copilot Coding Agent onboarding instructions (#148) ([1881c34](https://github.com/riderodd/react-native-vosk/commit/1881c34)), closes [#148](https://github.com/riderodd/react-native-vosk/issues/148)
+* chore: release 0.3.2 (#80) ([37ec42a](https://github.com/riderodd/react-native-vosk/commit/37ec42a)), closes [#80](https://github.com/riderodd/react-native-vosk/issues/80)
+* chore: updated release it deps (#105) ([b73429c](https://github.com/riderodd/react-native-vosk/commit/b73429c)), closes [#105](https://github.com/riderodd/react-native-vosk/issues/105)
+* chore(deps-dev): bump @react-native/metro-config from 0.76.1 to 0.79.2 (#118) ([a14e95a](https://github.com/riderodd/react-native-vosk/commit/a14e95a)), closes [#118](https://github.com/riderodd/react-native-vosk/issues/118)
+
+
+### BREAKING CHANGE
+
+* the model is not searched in the android project by default anymore
+
+* chore: release 1.0.0
+
 ## <small>2.1.6 (2025-09-12)</small>
 
 * fix: Fix format rate error on iOS (#104) ([d8fe8b0](https://github.com/riderodd/react-native-vosk/commit/d8fe8b0)), closes [#104](https://github.com/riderodd/react-native-vosk/issues/104)

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1835,7 +1835,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-vosk (2.1.5):
+  - react-native-vosk (2.1.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2643,7 +2643,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: 91e0eab42a6ae7f3e34091a126d70fc53bd3823e
   React-microtasksnativemodule: 1ead4fe154df3b1ba34b5a9e35ef3c4bdfa72ccb
   react-native-safe-area-context: c6e2edd1c1da07bdce287fa9d9e60c5f7b514616
-  react-native-vosk: 797d9009626d4bfa1b0522b7b1aa84def66c1f17
+  react-native-vosk: 2b4cd09c20a18339315a34740341982aa8a4b645
   React-NativeModulesApple: eff2eba56030eb0d107b1642b8f853bc36a833ac
   React-oscompat: b12c633e9c00f1f99467b1e0e0b8038895dae436
   React-perflogger: 58d12c4e5df1403030c97b9c621375c312cca454
@@ -2672,11 +2672,11 @@ SPEC CHECKSUMS:
   React-timing: 97ada2c47b4c5932e7f773c7d239c52b90d6ca68
   React-utils: f0949d247a46b4c09f03e5a3cb1167602d0b729a
   ReactAppDependencyProvider: 3eb9096cb139eb433965693bbe541d96eb3d3ec9
-  ReactCodegen: 4d203eddf6f977caa324640a20f92e70408d648b
+  ReactCodegen: e2251e4a041828c517fde8f6e1c062c4a89b88f4
   ReactCommon: ce5d4226dfaf9d5dacbef57b4528819e39d3a120
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 11c9686a21e2cd82a094a723649d9f4507200fb0
 
 PODFILE CHECKSUM: 605b934b5eb489405fbad7204a4924dc73596edb
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/ios/Vosk.mm
+++ b/ios/Vosk.mm
@@ -33,9 +33,10 @@ RCT_EXPORT_MODULE()
         dispatch_queue_create("recognizerQueue", DISPATCH_QUEUE_SERIAL);
     dispatch_queue_set_specific(_processingQueue, kVoskProcessingQueueKey,
                                 kVoskProcessingQueueKey, NULL);
-    _audioEngine = [AVAudioEngine new];
-    _inputNode = _audioEngine.inputNode;
-    _formatInput = [_inputNode inputFormatForBus:0];
+    // Lazy initialization to avoid triggering microphone permission prompt
+    _audioEngine = nil;
+    _inputNode = nil;
+    _formatInput = nil;
     _recognizer = NULL;
     _currentModel = nil;
     _lastPartial = nil;
@@ -93,6 +94,15 @@ RCT_EXPORT_MODULE()
   _isStarting = YES;
   _tapRetryCount = 0;
   _pendingTap = NO;
+  
+  // Lazy initialization of audio engine to avoid permission prompt at module load
+  if (!_audioEngine) {
+    _audioEngine = [AVAudioEngine new];
+  }
+  if (!_inputNode) {
+    _inputNode = _audioEngine.inputNode;
+  }
+  
   AVAudioSession *audioSession = [AVAudioSession sharedInstance];
 
   // Extract options (grammar, timeout) from the codegen structure
@@ -129,12 +139,14 @@ RCT_EXPORT_MODULE()
     if (catErr) {
       NSString *msg = [NSString stringWithFormat:@"Audio session category error: %@", catErr.localizedDescription];
       [self emitOnError:msg];
+      _isStarting = NO;
       reject(@"start", msg, catErr);
       return;
     }
   } @catch (NSException *ex) {
     NSString *msg = [NSString stringWithFormat:@"Exception setting category: %@", ex.reason ?: @"unknown"]; 
     [self emitOnError:msg];
+    _isStarting = NO;
     reject(@"start", msg, nil);
     return;
   }
@@ -145,6 +157,7 @@ RCT_EXPORT_MODULE()
       dispatch_async(dispatch_get_main_queue(), ^{
         NSString *msg = @"Microphone permission denied";
         [self emitOnError:msg];
+        self->_isStarting = NO;
         reject(@"start", msg, nil);
       });
       return;
@@ -154,6 +167,7 @@ RCT_EXPORT_MODULE()
       if (![audioSession setActive:YES error:&actErr]) {
         NSString *msg = [NSString stringWithFormat:@"Failed to activate audio session: %@", actErr.localizedDescription];
         [self emitOnError:msg];
+        self->_isStarting = NO;
         reject(@"start", msg, actErr);
         return;
       }
@@ -287,6 +301,9 @@ RCT_EXPORT_MODULE()
   if (_isRunning) {
     [self stopInternalWithoutEvents:NO];
   }
+  // Reset flags to allow restarting after unload
+  _isStarting = NO;
+  _isRunning = NO;
   _currentModel = nil;
 }
 
@@ -303,18 +320,18 @@ RCT_EXPORT_MODULE()
 
 // Internal cleanup
 - (void)stopInternalWithoutEvents:(BOOL)withoutEvents {
-  @try {
-    [_inputNode removeTapOnBus:0];
-  } @catch (...) {
-  }
-
-  if (!_isRunning) {
-    // already stopped
-  }
-  _isRunning = NO; // prevents new buffers from being processed
+  // Reset flags immediately to allow restart
+  _isRunning = NO;
   _isStarting = NO;
   _tapInstalled = NO;
   _pendingTap = NO;
+  
+  @try {
+    if (_inputNode) {
+      [_inputNode removeTapOnBus:0];
+    }
+  } @catch (...) {
+  }
 
   if (_audioEngine.isRunning) {
     [_audioEngine stop];

--- a/ios/Vosk.mm
+++ b/ios/Vosk.mm
@@ -301,9 +301,12 @@ RCT_EXPORT_MODULE()
   if (_isRunning) {
     [self stopInternalWithoutEvents:NO];
   }
-  // Reset flags to allow restarting after unload
+  // Reset all flags to ensure consistent state regardless of running state
   _isStarting = NO;
   _isRunning = NO;
+  _tapInstalled = NO;
+  _pendingTap = NO;
+  _tapRetryCount = 0;
   _currentModel = nil;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-vosk",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "Speech recognition module for react native using Vosk library",
   "types": "lib/typescript/src/index.d.ts",
   "main": "lib/commonjs/index.js",


### PR DESCRIPTION
Implement lazy initialization for the audio engine to prevent the microphone permission prompt at startup. Ensure proper unloading of the model and reset relevant flags for restarting. Update the `react-native-vosk` dependency version.